### PR TITLE
Finish unit tests

### DIFF
--- a/Example/Tests/XExtensionItemTestHelpers.h
+++ b/Example/Tests/XExtensionItemTestHelpers.h
@@ -46,6 +46,16 @@
         XExtensionItemAssertEqualItemProviderArrays(item1.attachments, item2.attachments); \
     }
 
+static NSDictionary *dictionaryByRemovingExtensionItemSystemKeys(NSDictionary *dictionary) {
+    NSMutableDictionary *mutableDictionary = [dictionary mutableCopy];
+    
+    for (NSString *key in @[NSExtensionItemAttributedTitleKey, NSExtensionItemAttributedContentTextKey, NSExtensionItemAttachmentsKey]) {
+        [mutableDictionary removeObjectForKey:key];
+    }
+    
+    return [mutableDictionary copy];
+}
+
 static void itemsForItemProvider(NSItemProvider *provider, void (^block)(NSArray *items)) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         NSMutableArray *items = [[NSMutableArray alloc] init];

--- a/Example/Tests/XExtensionItemTestHelpers.h
+++ b/Example/Tests/XExtensionItemTestHelpers.h
@@ -1,0 +1,97 @@
+@interface XExtensionItemSource (Testing)
+
+@property (nonatomic, readonly) id item;
+
+@end
+
+@implementation XExtensionItemSource (Testing)
+
+- (id)item {
+    return [self activityViewController:nil itemForActivityType:nil];
+}
+
+@end
+
+#define XExtensionItemAssertEqualItemProviderArrays(itemProviders, otherItemProviders)\
+    { \
+        XCTestExpectation *expectation = [self expectationWithDescription:@"Load item provider attachments"]; \
+        \
+        itemsForItemProviders(itemProviders, ^(NSArray *items) { \
+            itemsForItemProviders(otherItemProviders, ^(NSArray *otherItems) { \
+                XCTAssertEqualObjects(items, otherItems); \
+                \
+                [expectation fulfill]; \
+            }); \
+        }); \
+        \
+        [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) { \
+            if (error) { \
+                XCTFail(@"Expectation failed with error: %@", error); \
+            } \
+        }]; \
+    }
+
+#define XExtensionItemAssertEqualItems(object1, object2) \
+    { \
+        XCTAssertTrue([object1 isKindOfClass:[NSExtensionItem class]]); \
+        XCTAssertTrue([object2 isKindOfClass:[NSExtensionItem class]]); \
+        \
+        NSExtensionItem *item1 = (NSExtensionItem *)object1;\
+        NSExtensionItem *item2 = (NSExtensionItem *)object2;\
+        \
+        XCTAssertEqualObjects(item1.attributedTitle, item2.attributedTitle); \
+        XCTAssertEqualObjects(item1.attributedContentText, item2.attributedContentText); \
+        XCTAssertEqualObjects(dictionaryByRemovingExtensionItemSystemKeys(item1.userInfo), dictionaryByRemovingExtensionItemSystemKeys(item2.userInfo)); \
+        \
+        XExtensionItemAssertEqualItemProviderArrays(item1.attachments, item2.attachments); \
+    }
+
+static NSDictionary *dictionaryByRemovingExtensionItemSystemKeys(NSDictionary *dictionary) {
+    NSMutableDictionary *mutableDictionary = [dictionary mutableCopy];
+    
+    for (NSString *key in @[NSExtensionItemAttributedTitleKey, NSExtensionItemAttributedContentTextKey, NSExtensionItemAttachmentsKey]) {
+        [mutableDictionary removeObjectForKey:key];
+    }
+    
+    return [mutableDictionary copy];
+}
+
+static void itemsForItemProvider(NSItemProvider *provider, void (^block)(NSArray *items)) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSMutableArray *items = [[NSMutableArray alloc] init];
+        
+        for (NSString *identifier in provider.registeredTypeIdentifiers) {
+            dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+            
+            [provider loadItemForTypeIdentifier:identifier options:nil completionHandler:^(id<NSSecureCoding> item, NSError *error) {
+                [items addObject:item];
+                
+                dispatch_semaphore_signal(semaphore);
+            }];
+            
+            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+        }
+        
+        block(items);
+    });
+}
+
+static void itemsForItemProviders(NSArray/*<NSItemProvider>*/ *providers, void (^block)(NSArray *items)) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSMutableArray *items = [[NSMutableArray alloc] init];
+        
+        for (NSItemProvider *provider in providers) {
+            dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+            
+            itemsForItemProvider(provider, ^(NSArray *providerItems) {
+                [items addObjectsFromArray:providerItems];
+                
+                dispatch_semaphore_signal(semaphore);
+            });
+            
+            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+        }
+        
+        block(items);
+    });
+}

--- a/Example/Tests/XExtensionItemTestHelpers.h
+++ b/Example/Tests/XExtensionItemTestHelpers.h
@@ -46,16 +46,6 @@
         XExtensionItemAssertEqualItemProviderArrays(item1.attachments, item2.attachments); \
     }
 
-static NSDictionary *dictionaryByRemovingExtensionItemSystemKeys(NSDictionary *dictionary) {
-    NSMutableDictionary *mutableDictionary = [dictionary mutableCopy];
-    
-    for (NSString *key in @[NSExtensionItemAttributedTitleKey, NSExtensionItemAttributedContentTextKey, NSExtensionItemAttachmentsKey]) {
-        [mutableDictionary removeObjectForKey:key];
-    }
-    
-    return [mutableDictionary copy];
-}
-
 static void itemsForItemProvider(NSItemProvider *provider, void (^block)(NSArray *items)) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         NSMutableArray *items = [[NSMutableArray alloc] init];

--- a/Example/Tests/XExtensionItemTests.m
+++ b/Example/Tests/XExtensionItemTests.m
@@ -3,194 +3,114 @@
 @import XCTest;
 #import "CustomParameters.h"
 #import "XExtensionItem.h"
+#import "XExtensionItemTestHelpers.h"
 
 @interface XExtensionItemTests : XCTestCase
 @end
 
 @implementation XExtensionItemTests
 
-- (void)testItemSourceThrowsIfPlaceholderIsNil {
+#pragma mark - Initializers
+
+- (void)testURLInitializerThrowsIfNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithURL:nil]);
+}
+
+- (void)testURLInitializerProducesExtensionItemWithURLAttachment {
+    NSURL *URL = [NSURL URLWithString:@"http://tumblr.com"];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithURL:URL];
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypeURL]];
+
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testURLInitializerProducesExtensionItemWithFileURLAttachment {
+    NSURL *URL = [NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain" ofType:@"png"]];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithURL:URL];
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypePNG]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testStringInitializerThrowsIfNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithText:nil]);
+}
+
+- (void)testStringInitializerProducesExtensionItemWithStringAttachment {
+    NSString *string = @"foo";
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:string];
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:string typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testImageInitializerThrowsIfNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithImage:nil]);
+}
+
+- (void)testImageInitializerProducesExtensionItemWithImageAttachment {
+    UIImage *image = [[UIImage alloc] init];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithImage:image];
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:image typeIdentifier:(NSString *)kUTTypePNG]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testDataInitializerThrowsIfNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithData:nil typeIdentifier:(NSString *)kUTTypeGIF]);
+}
+
+- (void)testDataInitializerThrowsIfTypeIdentifierIsNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithData:[[NSData alloc] init] typeIdentifier:nil]);
+}
+
+- (void)testDataInitializerProducesExtensionItemWithDataAttachment {
+    NSData *data = [NSData dataWithContentsOfFile:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain" ofType:@"png"]];
+
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithData:data typeIdentifier:(NSString *)kUTTypePNG];
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:data typeIdentifier:(NSString *)kUTTypePNG]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testPlaceholderInitializerThrowsIfNil {
     XCTAssertThrows([[XExtensionItemSource alloc] initWithPlaceholderItem:nil typeIdentifier:nil itemBlock:nil]);
 }
 
-- (void)testAttributedTitle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.title = @"Foo";
+- (void)testPlaceholderInitializerProducesDifferentItemsBasedOnActivityType {
+    NSString *defaultString = @"foo";
+    NSString *twitterString = @"bar";
     
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqualObjects(itemSource.title, xExtensionItem.title);
-}
-
-- (void)testAttributedContentText {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.attributedContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqual(itemSource.attributedContentText.hash, xExtensionItem.attributedContentText.hash);
-}
-
-- (void)testAttachments {
-    NSURL *URL = [NSURL URLWithString:@"http://apple.com"];
-    
-    NSArray *additionalAttachments = @[
-        [[NSItemProvider alloc] initWithItem:[NSURL URLWithString:@"http://apple.com"] typeIdentifier:(__bridge NSString *)kUTTypeURL],
-        [[NSItemProvider alloc] initWithItem:@"Apple’s website" typeIdentifier:(__bridge NSString *)kUTTypeText]
-    ];
-    
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithURL:URL];
-    itemSource.additionalAttachments = additionalAttachments;
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqual(xExtensionItem.attachments.count, 3);
-}
-
-- (void)testTags {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.tags = @[@"foo", @"bar", @"baz"];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqualObjects(itemSource.tags, xExtensionItem.tags);
-}
-
-- (void)testSourceURL {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqualObjects(itemSource.sourceURL, xExtensionItem.sourceURL);
-}
-
-- (void)testReferrer {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-
-    itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppName:@"Tumblr"
-                                                               appStoreID:@"12345"
-                                                             googlePlayID:@"54321"
-                                                                   webURL:[NSURL URLWithString:@"http://bryan.io/a94kan4"]
-                                                                iOSAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]
-                                                            androidAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqualObjects(itemSource.referrer, xExtensionItem.referrer);
-}
-
-- (void)testReferrerFromBundle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppNameFromBundle:[NSBundle bundleForClass:[self class]]
-                                                                         appStoreID:@"12345"
-                                                                       googlePlayID:@"54321"
-                                                                             webURL:[NSURL URLWithString:@"http://bryan.io/a94kan4"]
-                                                                          iOSAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]
-                                                                      androidAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    XCTAssertEqualObjects(itemSource.referrer, xExtensionItem.referrer);
-}
-
-- (void)testUserInfo {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
-    itemSource.userInfo = @{ @"foo": @"bar" };
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    // Output params user info dictionary should be a superset of input params user info dictionary
-    
-    [itemSource.userInfo enumerateKeysAndObjectsUsingBlock:^(id inputKey, id inputValue, BOOL *stop) {
-        XCTAssertEqualObjects(xExtensionItem.userInfo[inputKey], inputValue);
-    }];
-}
-
-- (void)testAddEntriesToUserInfo {
-    CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];
-    inputCustomParameters.customParameter = @"Value";
-
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    [itemSource addCustomParameters:inputCustomParameters];
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    
-    CustomParameters *outputCustomParameters = [[CustomParameters alloc] initWithDictionary:xExtensionItem.userInfo];
-    
-    XCTAssertEqualObjects(inputCustomParameters, outputCustomParameters);
-}
-
-- (void)testTypeSafety {
-    /*
-     Try to break things by intentionally using the wrong types for these keys, then calling methods that would only
-     exist on the correct object types
-     */
-    
-    NSExtensionItem *item = [[NSExtensionItem alloc] init];
-    item.userInfo = @{
-        @"x-extension-item": @[],
-    };
-    
-    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:item];
-    XCTAssertNoThrow([xExtensionItem.sourceURL absoluteString]);
-    
-    item = [[NSExtensionItem alloc] init];
-    item.userInfo = @{
-        @"x-extension-item": @{
-            @"source-url": @"",
-            @"tags": @{},
-            @"referrer-name": @[],
-            @"referrer-app-store-id": @[],
-            @"referrer-google-play-id": @[],
-            @"referrer-web-url": @[],
-            @"referrer-ios-app-url": @[],
-            @"referrer-android-app-url": @[]
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"placeholder" typeIdentifier:nil itemBlock:^id(NSString *activityType) {
+        if (activityType == UIActivityTypePostToTwitter) {
+            return twitterString;
         }
-    };
+        else {
+            return defaultString;
+        }
+    }];
     
-    xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:item];
-    XCTAssertNoThrow([xExtensionItem.sourceURL absoluteString]);
-    XCTAssertNoThrow(xExtensionItem.tags.count);
-    XCTAssertNoThrow([xExtensionItem.referrer.appName stringByAppendingString:@""]);
-    XCTAssertNoThrow([xExtensionItem.referrer.appStoreID stringByAppendingString:@""]);
-    XCTAssertNoThrow([xExtensionItem.referrer.googlePlayID stringByAppendingString:@""]);
-    XCTAssertNoThrow([xExtensionItem.referrer.webURL absoluteString]);
-    XCTAssertNoThrow([xExtensionItem.referrer.iOSAppURL absoluteString]);
-    XCTAssertNoThrow([xExtensionItem.referrer.androidAppURL absoluteString]);
+    NSExtensionItem *expectedTwitter = [[NSExtensionItem alloc] init];
+    expectedTwitter.attachments = @[[[NSItemProvider alloc] initWithItem:twitterString typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(expectedTwitter, [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter]);
+    
+    NSExtensionItem *expectedNonTwitter = [[NSExtensionItem alloc] init];
+    expectedNonTwitter.attachments = @[[[NSItemProvider alloc] initWithItem:defaultString typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(expectedNonTwitter, [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToFacebook]);
 }
 
-- (void)testAdditionalAttachmentsForActivityTypeClearedByPassingNil {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    [itemSource setAdditionalAttachments:@[@"String"] forActivityType:UIActivityTypeMail];
-    [itemSource setAdditionalAttachments:nil forActivityType:UIActivityTypeMail];
-  
-    XExtensionItem *extensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
-    XCTAssertEqual(extensionItem.attachments.count, 1);
-}
-
-- (void)testRegisteringSubjectReturnsRegisteredSubjectForMailActivity {
-    NSString *subject = @"Subject";
-    
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.title = subject;
-    
-    XCTAssertEqualObjects(subject, [itemSource activityViewController:nil subjectForActivityType:UIActivityTypeMail]);
-}
-
-- (void)testRegisteringThumbnailProvidingBlockReturnsThumbnailForTwitterActivity {
-    UIImage *image = [[UIImage alloc] initWithData:[@"" dataUsingEncoding:NSUTF8StringEncoding]];
-    
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
-    itemSource.thumbnailProvider = ^(CGSize suggestedSize, NSString *activityType) {
-        return image;
-    };
-    
-    XCTAssertEqualObjects(image, [itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypePostToTwitter suggestedSize:CGSizeZero]);
-}
-
-- (void)testDataTypeIdentifierPassedToInitializerIsReturnedByActivityItemSourceDelegateMethods {
+- (void)testPlaceholderProvidedTypeIdentifierIsReturnedByActivityItemSourceDelegateMethod {
     NSString *dataTypeIdentifier = (NSString *)kUTTypeVideo;
     
     XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithPlaceholderItem:[[NSData alloc] init]
@@ -200,7 +120,35 @@
     XCTAssertEqualObjects(dataTypeIdentifier, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
 }
 
-- (void)testTextReturnedForSystemActivityThatCantProcessExtensionItemInput {
+- (void)testPlaceholderTypeIdentifierIsInferredForURL {
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithURL:[NSURL URLWithString:@"http://irace.me"]];
+    
+    XCTAssertEqualObjects((NSString *)kUTTypeURL, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
+}
+
+- (void)testPlaceholderTypeIdentifierIsInferredForFileURL {
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithURL:
+                                    [NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain"
+                                                                                                          ofType:@"png"]]];
+    
+    XCTAssertEqualObjects((NSString *)kUTTypePNG, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
+}
+
+- (void)testPlaceholderTypeIdentifierIsInferredForString {
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:@"Foo"];
+    
+    XCTAssertEqualObjects((NSString *)kUTTypePlainText, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
+}
+
+- (void)testPlaceholderTypeIdentifierIsInferredForImage {
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithImage:[[UIImage alloc] init]];
+    
+    XCTAssertEqualObjects((NSString *)kUTTypeImage, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
+}
+
+#pragma mark - Output verification
+
+- (void)testTextReturnedForSystemActivityThatCannotProcessExtensionItemInput {
     NSString *text = @"Foo";
     
     XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:text];
@@ -235,6 +183,364 @@
     NSExtensionItem *actual = [source activityViewController:nil itemForActivityType:@"com.irace.me.SomeExtension"];
     
     XCTAssertTrue([actual isKindOfClass:[NSExtensionItem class]]);
+}
+
+#pragma mark - Title/content text
+
+- (void)testTitle {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.title = @"Foo";
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqualObjects(itemSource.title, xExtensionItem.title);
+}
+
+- (void)testTitleReturnedForSubject {
+    NSString *subject = @"Subject";
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.title = subject;
+    
+    XCTAssertEqualObjects(subject, [itemSource activityViewController:nil subjectForActivityType:UIActivityTypeMail]);
+}
+
+- (void)testAttributedContentText {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.attributedContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqual(itemSource.attributedContentText.hash, xExtensionItem.attributedContentText.hash);
+}
+
+- (void)testSeparateAttributedContentTextValueForTwitter {
+    NSAttributedString *defaultContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
+    NSAttributedString *twitterContentText = [[NSAttributedString alloc] initWithString:@"Bar" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:10] }];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.attributedContentText = defaultContentText;
+    [itemSource setAttributedContentText:twitterContentText forActivityType:UIActivityTypePostToTwitter];
+
+    NSExtensionItem *defaultExtensionItem = [itemSource activityViewController:nil itemForActivityType:nil];
+    
+    // Wish I could test `NSAttributedString` equality here, but `NSExtensionItem`’s `attributedContentText` setter appears to add an `NSParagraphStyle` attribute
+    XCTAssertEqualObjects(defaultContentText.string, defaultExtensionItem.attributedContentText.string);
+    
+    NSExtensionItem *twitterExtensionItem = [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter];
+    
+    // Wish I could test `NSAttributedString` equality here, but `NSExtensionItem`’s `attributedContentText` setter appears to add an `NSParagraphStyle` attribute
+    XCTAssertEqualObjects(twitterContentText.string, twitterExtensionItem.attributedContentText.string);
+}
+
+- (void)testAttributedContentForActivityTypeClearedByPassingNil {
+    NSAttributedString *defaultContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
+    NSAttributedString *twitterContentText = [[NSAttributedString alloc] initWithString:@"Bar" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:10] }];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.attributedContentText = defaultContentText;
+    [itemSource setAttributedContentText:twitterContentText forActivityType:UIActivityTypePostToTwitter];
+    
+    NSExtensionItem *defaultExtensionItem = [itemSource activityViewController:nil itemForActivityType:nil];
+    NSExtensionItem *twitterExtensionItem = [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter];
+    
+    XCTAssertNotNil(defaultExtensionItem.attributedContentText);
+    XCTAssertNotNil(twitterExtensionItem.attributedContentText);
+    
+    [itemSource setAttributedContentText:nil forActivityType:nil];
+    
+    defaultExtensionItem = [itemSource activityViewController:nil itemForActivityType:nil];
+    twitterExtensionItem = [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter];
+    
+    XCTAssertNil(defaultExtensionItem.attributedContentText);
+    XCTAssertNotNil(twitterExtensionItem.attributedContentText);
+    
+    [itemSource setAttributedContentText:nil forActivityType:UIActivityTypePostToTwitter];
+
+    defaultExtensionItem = [itemSource activityViewController:nil itemForActivityType:nil];
+    twitterExtensionItem = [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter];
+    
+    XCTAssertNil(defaultExtensionItem.attributedContentText);
+    XCTAssertNil(twitterExtensionItem.attributedContentText);
+}
+
+#pragma mark - Attachments
+
+- (void)testAttachments {
+    NSURL *URL = [NSURL URLWithString:@"http://apple.com"];
+    
+    NSArray *additionalAttachments = @[
+        [[NSItemProvider alloc] initWithItem:[NSURL URLWithString:@"http://apple.com"] typeIdentifier:(__bridge NSString *)kUTTypeURL],
+        [[NSItemProvider alloc] initWithItem:@"Apple’s website" typeIdentifier:(__bridge NSString *)kUTTypeText]
+    ];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithURL:URL];
+    itemSource.additionalAttachments = additionalAttachments;
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+
+    NSArray *expected = ({
+        NSMutableArray *array = [[NSMutableArray alloc] init];
+        [array addObject:[[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypeURL]];
+        [array addObjectsFromArray:additionalAttachments];
+        [array copy];
+    });
+    
+    XExtensionItemAssertEqualItemProviderArrays(expected, xExtensionItem.attachments);
+}
+
+- (void)testItemProviderCreatedFromURLAdditionalAttachment {
+    NSString *text = @"foo";
+    NSURL *URL = [NSURL URLWithString:@"http://tumblr.com"];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    itemSource.additionalAttachments = @[URL];
+    
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:text typeIdentifier:(NSString *)kUTTypePlainText],
+                             [[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypeURL]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testItemProviderCreatedFromFileURLAdditionalAttachment {
+    NSString *text = @"foo";
+    NSURL *URL = [NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain"
+                                                                                       ofType:@"png"]];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    itemSource.additionalAttachments = @[URL];
+    
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:text typeIdentifier:(NSString *)kUTTypePlainText],
+                             [[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypePNG]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testItemProviderCreatedFromStringAdditionalAttachment {
+    NSString *text = @"foo";
+    NSString *text2 = @"bar";
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    itemSource.additionalAttachments = @[text2];
+    
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:text typeIdentifier:(NSString *)kUTTypePlainText],
+                             [[NSItemProvider alloc] initWithItem:text2 typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testItemProviderCreatedFromImageAdditionalAttachment {
+    NSString *text = @"foo";
+    UIImage *image = [[UIImage alloc] init];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    itemSource.additionalAttachments = @[image];
+    
+    NSExtensionItem *expected = [[NSExtensionItem alloc] init];
+    expected.attachments = @[[[NSItemProvider alloc] initWithItem:text typeIdentifier:(NSString *)kUTTypePlainText],
+                             [[NSItemProvider alloc] initWithItem:image typeIdentifier:(NSString *)kUTTypePNG]];
+    
+    XExtensionItemAssertEqualItems(itemSource.item, expected);
+}
+
+- (void)testSeparateAdditionalAttachmentsForTwitter {
+    NSURL *URL = [NSURL URLWithString:@"http://tumblr.com"];
+    NSString *defaultText = @"foo";
+    NSString *twitterText = @"bar";
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithURL:URL];
+    itemSource.additionalAttachments = @[defaultText];
+    [itemSource setAdditionalAttachments:@[twitterText] forActivityType:UIActivityTypePostToTwitter];
+    
+    NSExtensionItem *defaultExpected = [[NSExtensionItem alloc] init];
+    defaultExpected.attachments = @[[[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypeURL],
+                                    [[NSItemProvider alloc] initWithItem:defaultText typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(defaultExpected, [itemSource activityViewController:nil itemForActivityType:nil]);
+    
+    NSExtensionItem *twitterExpected = [[NSExtensionItem alloc] init];
+    twitterExpected.attachments = @[[[NSItemProvider alloc] initWithItem:URL typeIdentifier:(NSString *)kUTTypeURL],
+                                    [[NSItemProvider alloc] initWithItem:twitterText typeIdentifier:(NSString *)kUTTypePlainText]];
+    
+    XExtensionItemAssertEqualItems(twitterExpected, [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToTwitter]);
+}
+
+- (void)testAdditionalAttachmentsForActivityTypeClearedByPassingNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    [itemSource setAdditionalAttachments:@[@"String"] forActivityType:UIActivityTypeMail];
+    [itemSource setAdditionalAttachments:nil forActivityType:UIActivityTypeMail];
+    
+    XExtensionItem *extensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    XCTAssertEqual(extensionItem.attachments.count, 1);
+}
+
+#pragma mark - Parameters
+
+- (void)testTags {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.tags = @[@"foo", @"bar", @"baz"];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqualObjects(itemSource.tags, xExtensionItem.tags);
+}
+
+- (void)testSourceURL {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqualObjects(itemSource.sourceURL, xExtensionItem.sourceURL);
+}
+
+- (void)testReferrer {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+
+    itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppName:@"Tumblr"
+                                                               appStoreID:@"12345"
+                                                             googlePlayID:@"54321"
+                                                                   webURL:[NSURL URLWithString:@"http://bryan.io/a94kan4"]
+                                                                iOSAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]
+                                                            androidAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqualObjects(itemSource.referrer, xExtensionItem.referrer);
+}
+
+- (void)testReferrerFromBundle {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppNameFromBundle:[NSBundle bundleForClass:[self class]]
+                                                                         appStoreID:@"12345"
+                                                                       googlePlayID:@"54321"
+                                                                             webURL:[NSURL URLWithString:@"http://bryan.io/a94kan4"]
+                                                                          iOSAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]
+                                                                      androidAppURL:[NSURL URLWithString:@"tumblr://a94kan4"]];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    XCTAssertEqualObjects(itemSource.referrer, xExtensionItem.referrer);
+}
+
+- (void)testThumbnailProvider {
+    UIImage *emailImage = [[UIImage alloc] initWithData:[@"123" dataUsingEncoding:NSUTF8StringEncoding]];
+    UIImage *defaultImage = [[UIImage alloc] initWithData:[@"456" dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.thumbnailProvider = ^(CGSize suggestedSize, NSString *activityType) {
+        if (activityType == UIActivityTypeMail) {
+            return emailImage;
+        }
+        else {
+            return defaultImage;
+        }
+        
+    };
+    
+    XCTAssertEqualObjects(emailImage, [itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypePostToTwitter suggestedSize:CGSizeZero]);
+    XCTAssertEqualObjects(defaultImage, [itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypeMail suggestedSize:CGSizeZero]);
+}
+
+- (void)testActivityItemSourceDelegateDoesNotThrowIfNoThumbnailBlock {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+
+    XCTAssertNoThrow([itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypePostToTwitter suggestedSize:CGSizeZero]);
+}
+
+#pragma mark - Custom parameters
+
+- (void)testUserInfo {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
+    itemSource.userInfo = @{ @"foo": @"bar" };
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    // Output params user info dictionary should be a superset of input params user info dictionary
+    
+    [itemSource.userInfo enumerateKeysAndObjectsUsingBlock:^(id inputKey, id inputValue, BOOL *stop) {
+        XCTAssertEqualObjects(xExtensionItem.userInfo[inputKey], inputValue);
+    }];
+}
+
+- (void)testCustomParameters {
+    CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];
+    inputCustomParameters.customParameter = @"Value";
+
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    [itemSource addCustomParameters:inputCustomParameters];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    CustomParameters *outputCustomParameters = [[CustomParameters alloc] initWithDictionary:xExtensionItem.userInfo];
+    
+    XCTAssertEqualObjects(inputCustomParameters, outputCustomParameters);
+}
+
+- (void)testUserInfoAndCustomParameters {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    itemSource.userInfo = @{ @"foo": @"bar" };
+    
+    CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];
+    inputCustomParameters.customParameter = @"Value";
+
+    [itemSource addCustomParameters:inputCustomParameters];
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
+    
+    // Output params user info dictionary should be a superset of input params user info dictionary
+    
+    [itemSource.userInfo enumerateKeysAndObjectsUsingBlock:^(id inputKey, id inputValue, BOOL *stop) {
+        XCTAssertEqualObjects(xExtensionItem.userInfo[inputKey], inputValue);
+    }];
+    
+    CustomParameters *outputCustomParameters = [[CustomParameters alloc] initWithDictionary:xExtensionItem.userInfo];
+    
+    XCTAssertEqualObjects(inputCustomParameters, outputCustomParameters);
+}
+
+#pragma mark - Misc.
+
+- (void)testTypeSafety {
+    /*
+     Try to break things by intentionally using the wrong types for these keys, then calling methods that would only
+     exist on the correct object types
+     */
+    
+    NSExtensionItem *item = [[NSExtensionItem alloc] init];
+    item.userInfo = @{
+                      @"x-extension-item": @[],
+                      };
+    
+    XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:item];
+    XCTAssertNoThrow([xExtensionItem.sourceURL absoluteString]);
+    
+    item = [[NSExtensionItem alloc] init];
+    item.userInfo = @{
+                      @"x-extension-item": @{
+                              @"source-url": @"",
+                              @"tags": @{},
+                              @"referrer-name": @[],
+                              @"referrer-app-store-id": @[],
+                              @"referrer-google-play-id": @[],
+                              @"referrer-web-url": @[],
+                              @"referrer-ios-app-url": @[],
+                              @"referrer-android-app-url": @[]
+                              }
+                      };
+    
+    xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:item];
+    XCTAssertNoThrow([xExtensionItem.sourceURL absoluteString]);
+    XCTAssertNoThrow(xExtensionItem.tags.count);
+    XCTAssertNoThrow([xExtensionItem.referrer.appName stringByAppendingString:@""]);
+    XCTAssertNoThrow([xExtensionItem.referrer.appStoreID stringByAppendingString:@""]);
+    XCTAssertNoThrow([xExtensionItem.referrer.googlePlayID stringByAppendingString:@""]);
+    XCTAssertNoThrow([xExtensionItem.referrer.webURL absoluteString]);
+    XCTAssertNoThrow([xExtensionItem.referrer.iOSAppURL absoluteString]);
+    XCTAssertNoThrow([xExtensionItem.referrer.androidAppURL absoluteString]);
 }
 
 @end

--- a/Example/Tests/XExtensionItemTests.m
+++ b/Example/Tests/XExtensionItemTests.m
@@ -37,13 +37,13 @@
 }
 
 - (void)testStringInitializerThrowsIfNil {
-    XCTAssertThrows([[XExtensionItemSource alloc] initWithText:nil]);
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithString:nil]);
 }
 
 - (void)testStringInitializerProducesExtensionItemWithStringAttachment {
     NSString *string = @"foo";
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:string];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:string];
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
     expected.attachments = @[[[NSItemProvider alloc] initWithItem:string typeIdentifier:(NSString *)kUTTypePlainText]];
     
@@ -135,7 +135,7 @@
 }
 
 - (void)testPlaceholderTypeIdentifierIsInferredForString {
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:@"Foo"];
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithString:@"Foo"];
     
     XCTAssertEqualObjects((NSString *)kUTTypePlainText, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
 }
@@ -151,7 +151,7 @@
 - (void)testTextReturnedForSystemActivityThatCannotProcessExtensionItemInput {
     NSString *text = @"Foo";
     
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:text];
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithString:text];
     source.additionalAttachments = @[[[NSItemProvider alloc] initWithItem:@"Bar" typeIdentifier:(NSString *)kUTTypeText]];
     
     XCTAssertEqualObjects(text, [source activityViewController:nil itemForActivityType:UIActivityTypeMail]);
@@ -160,7 +160,7 @@
 - (void)testExtensionItemReturnedForSystemActivityThatCanProcessExtensionItemInput {
     NSArray *attachments = @[[[NSItemProvider alloc] initWithItem:@"Bar" typeIdentifier:(NSString *)kUTTypeText]];
     
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithString:@""];
     source.additionalAttachments = attachments;
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -174,7 +174,7 @@
 - (void)testExtensionItemReturnedForNonSystemExtension {
     NSArray *attachments = @[[[NSItemProvider alloc] initWithItem:@"Bar" typeIdentifier:(NSString *)kUTTypeText]];
     
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithString:@""];
     source.additionalAttachments = attachments;
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -188,7 +188,7 @@
 #pragma mark - Title/content text
 
 - (void)testTitle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.title = @"Foo";
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
@@ -199,14 +199,14 @@
 - (void)testTitleReturnedForSubject {
     NSString *subject = @"Subject";
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.title = subject;
     
     XCTAssertEqualObjects(subject, [itemSource activityViewController:nil subjectForActivityType:UIActivityTypeMail]);
 }
 
 - (void)testAttributedContentText {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.attributedContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
@@ -218,7 +218,7 @@
     NSAttributedString *defaultContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
     NSAttributedString *twitterContentText = [[NSAttributedString alloc] initWithString:@"Bar" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:10] }];
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.attributedContentText = defaultContentText;
     [itemSource setAttributedContentText:twitterContentText forActivityType:UIActivityTypePostToTwitter];
 
@@ -237,7 +237,7 @@
     NSAttributedString *defaultContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
     NSAttributedString *twitterContentText = [[NSAttributedString alloc] initWithString:@"Bar" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:10] }];
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.attributedContentText = defaultContentText;
     [itemSource setAttributedContentText:twitterContentText forActivityType:UIActivityTypePostToTwitter];
     
@@ -293,7 +293,7 @@
     NSString *text = @"foo";
     NSURL *URL = [NSURL URLWithString:@"http://tumblr.com"];
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@"foo"];
     itemSource.additionalAttachments = @[URL];
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -307,7 +307,7 @@
     NSString *text = @"foo";
     NSURL *URL = [NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain"
                                                                                        ofType:@"png"]];
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@"foo"];
     itemSource.additionalAttachments = @[URL];
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -321,7 +321,7 @@
     NSString *text = @"foo";
     NSString *text2 = @"bar";
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@"foo"];
     itemSource.additionalAttachments = @[text2];
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -335,7 +335,7 @@
     NSString *text = @"foo";
     UIImage *image = [[UIImage alloc] init];
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@"foo"];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@"foo"];
     itemSource.additionalAttachments = @[image];
     
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
@@ -368,7 +368,7 @@
 }
 
 - (void)testAdditionalAttachmentsForActivityTypeClearedByPassingNil {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     [itemSource setAdditionalAttachments:@[@"String"] forActivityType:UIActivityTypeMail];
     [itemSource setAdditionalAttachments:nil forActivityType:UIActivityTypeMail];
     
@@ -379,7 +379,7 @@
 #pragma mark - Parameters
 
 - (void)testTags {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.tags = @[@"foo", @"bar", @"baz"];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
@@ -388,7 +388,7 @@
 }
 
 - (void)testSourceURL {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
@@ -397,7 +397,7 @@
 }
 
 - (void)testReferrer {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
 
     itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppName:@"Tumblr"
                                                                appStoreID:@"12345"
@@ -412,7 +412,7 @@
 }
 
 - (void)testReferrerFromBundle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppNameFromBundle:[NSBundle bundleForClass:[self class]]
                                                                          appStoreID:@"12345"
                                                                        googlePlayID:@"54321"
@@ -429,7 +429,7 @@
     UIImage *emailImage = [[UIImage alloc] initWithData:[@"123" dataUsingEncoding:NSUTF8StringEncoding]];
     UIImage *defaultImage = [[UIImage alloc] initWithData:[@"456" dataUsingEncoding:NSUTF8StringEncoding]];
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.thumbnailProvider = ^(CGSize suggestedSize, NSString *activityType) {
         if (activityType == UIActivityTypeMail) {
             return emailImage;
@@ -445,7 +445,7 @@
 }
 
 - (void)testActivityItemSourceDelegateDoesNotThrowIfNoThumbnailBlock {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
 
     XCTAssertNoThrow([itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypePostToTwitter suggestedSize:CGSizeZero]);
 }
@@ -453,7 +453,7 @@
 #pragma mark - Custom parameters
 
 - (void)testUserInfo {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
     itemSource.userInfo = @{ @"foo": @"bar" };
     
@@ -470,7 +470,7 @@
     CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];
     inputCustomParameters.customParameter = @"Value";
 
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     [itemSource addCustomParameters:inputCustomParameters];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:itemSource.item];
@@ -481,7 +481,7 @@
 }
 
 - (void)testUserInfoAndCustomParameters {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithText:@""];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithString:@""];
     itemSource.userInfo = @{ @"foo": @"bar" };
     
     CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];

--- a/Example/XExtensionItem.xcodeproj/project.pbxproj
+++ b/Example/XExtensionItem.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		9384B3FE1AF1614100960EF7 /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9384B3FD1AF1614100960EF7 /* ShareViewController.m */; };
 		9384B4001AF1614100960EF7 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9384B3FF1AF1614100960EF7 /* MainInterface.storyboard */; };
 		9384B4031AF1614100960EF7 /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9384B3F81AF1614100960EF7 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9388E6711B03A24900775CC9 /* mountain.png in Resources */ = {isa = PBXBuildFile; fileRef = 9388E6701B03A24900775CC9 /* mountain.png */; };
 		984F574C2FA43194C8C80DD4 /* libPods-XExtensionItem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 522AC9D97FEA882750D86BD6 /* libPods-XExtensionItem.a */; };
 		9DAE8AE3708DB46E11453D97 /* libPods-ShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A40DEC0AFFF91D68B1774179 /* libPods-ShareExtension.a */; };
 /* End PBXBuildFile section */
@@ -98,6 +99,8 @@
 		9384B3FC1AF1614100960EF7 /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
 		9384B3FD1AF1614100960EF7 /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
 		9384B3FF1AF1614100960EF7 /* MainInterface.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
+		9388E66F1B03966D00775CC9 /* XExtensionItemTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XExtensionItemTestHelpers.h; sourceTree = "<group>"; };
+		9388E6701B03A24900775CC9 /* mountain.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = mountain.png; path = ../../../../../Desktop/mountain.png; sourceTree = "<group>"; };
 		9A6E84F017B092F5A19805F8 /* Pods-XExtensionItem.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XExtensionItem.release.xcconfig"; path = "Pods/Target Support Files/Pods-XExtensionItem/Pods-XExtensionItem.release.xcconfig"; sourceTree = "<group>"; };
 		A40DEC0AFFF91D68B1774179 /* libPods-ShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF8BB31896275DB3F779A30B /* Pods-ShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-ShareExtension/Pods-ShareExtension.release.xcconfig"; sourceTree = "<group>"; };
@@ -202,6 +205,7 @@
 				9384B3DE1AF15E2700960EF7 /* CustomParameters.h */,
 				9384B3DF1AF15E2700960EF7 /* CustomParameters.m */,
 				9384B3E01AF15E2700960EF7 /* XExtensionItemTests.m */,
+				9388E66F1B03966D00775CC9 /* XExtensionItemTestHelpers.h */,
 				9384B3E11AF15E2700960EF7 /* XExtensionItemTypeSafeDictionaryValuesTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
@@ -211,6 +215,7 @@
 		6003F5B6195388D20070C39A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				9388E6701B03A24900775CC9 /* mountain.png */,
 				6003F5B7195388D20070C39A /* Tests-Info.plist */,
 				6003F5B8195388D20070C39A /* InfoPlist.strings */,
 				606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */,
@@ -393,6 +398,7 @@
 			files = (
 				6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */,
 				9384B3E61AF15E4100960EF7 /* XExtensionItem.podspec.json in Resources */,
+				9388E6711B03A24900775CC9 /* mountain.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pod/Classes/XExtensionItem.h
+++ b/Pod/Classes/XExtensionItem.h
@@ -138,11 +138,14 @@ typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize, 
 @property (nonatomic, copy) XExtensionItemThumbnailProvidingBlock thumbnailProvider;
 
 /**
- Add parameters from a dictionary-serializable custom parameters object.
+ Add parameters from a custom parameters object.
  
- @param dictionarySerializable A custom parameters object.
+ @discussion third-party developers to create an object that conforms to `XExtensionItemCustomParameters`, and open a 
+ pull request to add it to the `XExtensionItem` repository. See `XExtensionItemTumblrParameters` for an example of this.
+ 
+ @param customParameters A custom parameters object.
  */
-- (void)addCustomParameters:(id <XExtensionItemCustomParameters>)dictionarySerializable;
+- (void)addCustomParameters:(id <XExtensionItemCustomParameters>)customParameters;
 
 /**
  An optional dictionary of keys and values.

--- a/Pod/Classes/XExtensionItem.h
+++ b/Pod/Classes/XExtensionItem.h
@@ -178,11 +178,11 @@ typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize, 
 /**
  Initialize an item source with a string.
  
- @param text (Required) Text to be shared.
+ @param string (Required) String to be shared.
  
  @return New item source instance.
  */
-- (instancetype)initWithText:(NSString *)text;
+- (instancetype)initWithString:(NSString *)string;
 
 /**
  Initialize an item source with an image.
@@ -283,11 +283,11 @@ typedef NSData *(^XExtensionItemDataProvidingBlock)(NSString *activityType);
 /**
  Initialize an item source with a block that can provide a string.
  
- @param textProvider (Required) Text-providing block.
+ @param stringProvider (Required) String-providing block.
  
  @return New item source instance.
  */
-- (instancetype)initWithTextProvider:(XExtensionItemStringProvidingBlock)textProvider;
+- (instancetype)initWithStringProvider:(XExtensionItemStringProvidingBlock)stringProvider;
 
 /**
  Initialize an item source with a block that can provide an image.

--- a/Pod/Classes/XExtensionItem.m
+++ b/Pod/Classes/XExtensionItem.m
@@ -55,8 +55,8 @@ static NSString * const ActivityTypeCatchAll = @"*";
                                itemBlock:nil];
 }
 
-- (instancetype)initWithText:(NSString *)text {
-    return [self initWithPlaceholderItem:text
+- (instancetype)initWithString:(NSString *)string {
+    return [self initWithPlaceholderItem:string
                           typeIdentifier:(NSString *)kUTTypePlainText
                                itemBlock:nil];
 }
@@ -343,12 +343,12 @@ static BOOL isExtensionItemInputAcceptedByActivityType(NSString *activityType) {
                                itemBlock:fileURLProvider];
 }
 
-- (instancetype)initWithTextProvider:(XExtensionItemStringProvidingBlock)textProvider {
-    NSParameterAssert(textProvider);
+- (instancetype)initWithStringProvider:(XExtensionItemStringProvidingBlock)stringProvider {
+    NSParameterAssert(stringProvider);
     
     return [self initWithPlaceholderItem:[[NSString alloc] init]
                           typeIdentifier:(NSString *)kUTTypePlainText
-                               itemBlock:textProvider];
+                               itemBlock:stringProvider];
 }
 
 - (instancetype)initWithImageProvider:(XExtensionItemImageProvidingBlock)imageProvider {


### PR DESCRIPTION
- Added a bunch of tests
- Fixed a bug where `activityType` wasn’t being considered when returning `attributedContentText`
- Removed support for `NSDictionary`/`kUTTypePropertyList` items/attachments since AFAIK we don’t actually think this is a real use case?
- Renamed `initWithText:` to `initWithString:`
